### PR TITLE
Implement subagent support via RPC mode

### DIFF
--- a/.plans/implement-subagent-support.md
+++ b/.plans/implement-subagent-support.md
@@ -1,0 +1,262 @@
+# Plan: Implement Subagent Support
+
+## Objective
+
+Expose agent definitions as callable tools ("subagents") that allow an active agent to invoke another agent with a scoped goal, receive its output as a tool result, and resume its own workflow — all without the permanent handoff that `switch_agent` performs. This implements GitHub Issue #3.
+
+## Context
+
+### Repository Layout
+- `src/index.ts` — Main Pi extension entrypoint; registers `/agent` command, `switch_agent` tool, event handlers for `session_start`, `before_agent_start`, `session_shutdown`
+- `src/agent-discovery.ts` — Agent discovery from `~/.pi/agent/agents/*.md`, `.pi/agents/*.md`, and legacy `prompts/` directories; parses YAML frontmatter via `parseFrontmatter()`
+- `package.json` — Extension manifest with `pi.extensions` pointing to `./src/index.ts`
+- README.md — User-facing documentation covering agent directory conventions, `/agent` command, and `switch_agent` tool
+
+### Current Architecture
+- Agents are discovered as Markdown files with YAML frontmatter (`description`) and a body `content` (role description)
+- `switch_agent` tool performs a **permanent handoff**: updates `activeAgentName`, appends an `agent-state` entry, and the next `before_agent_start` injects the new agent's content into the system prompt
+- There is **no call-and-return mechanism**: once `switch_agent` fires, the caller agent is gone
+
+### Pi Extension API Constraints
+- `pi.registerTool()` can dynamically register tools at runtime
+- `pi.sendMessage()` / `pi.sendUserMessage()` can inject messages and trigger turns, but there is **no native "run subagent within same session" API**
+- `before_agent_start` is a global event handler; it cannot target a specific turn as "subagent mode"
+- Extensions **cannot directly invoke the LLM** — there is no `callLLM(systemPrompt, prompt)` API
+- `ctx.newSession()` creates a **replacement** session (caller is lost), not a nested subagent session
+- `pi.exec()` can spawn external processes synchronously from within a tool `execute()` handler
+
+### Tree-of-Thought: Subagent Execution Strategies
+
+**Path A: Separate Pi Process via RPC Mode**
+- Spawn a new `pi` CLI process with `--mode rpc`, set the subagent's system prompt via `--system-prompt <agent-file>`, send the scoped goal as a `prompt` command over stdin, consume the JSONL event stream from stdout, and extract the final assistant response from the `agent_end` event
+- Pros: True isolated subagent execution with correct system prompt; subagent can use tools (read, bash, etc.); accurate bounded execution via `turn_end` event counting; clean output extraction from structured `agent_end.messages`; natural timeout and abort support via `abort` command and `ctx.signal`
+- Cons: Heavyweight; separate token billing; requires `pi` binary available in PATH; more complex JSONL client implementation
+- Verdict: **Selected as MVP** — RPC mode is the richest subprocess-based approach available within current API constraints
+
+**Path B: Prompt Injection / Simulation**
+- Temporarily inject subagent content into `before_agent_start` for one turn, capture the assistant response, restore caller agent
+- Pros: Lightweight; same session; no external process
+- Cons: Cannot reliably "restore caller" after a single turn — `before_agent_start` fires for every turn indiscriminately; would require complex turn-tracking state machine that is fragile
+- Verdict: Rejected — too fragile given current event model
+
+**Path C: Wait for Pi Core Subagent API**
+- Do nothing now; document the requirement for a future Pi core API
+- Pros: Cleanest eventual architecture
+- Cons: Delivers zero value now; timeline unknown
+- Verdict: Partial — document what Pi core would need, but implement Path A as MVP
+
+## Architectural Blueprint
+
+### Phase 1: Metadata & Discovery
+Extend `AgentDefinition` and agent frontmatter schema to declare subagent capability, tool parameters, and execution bounds.
+
+### Phase 2: Dynamic Tool Registration
+At extension load and on `/reload`, discover all agents marked `subagent: true` and register each as a Pi tool via `pi.registerTool()`. The tool name is derived from the agent name (e.g., `invoke_reviewer`).
+
+### Phase 3: Subagent Tool Execution via RPC
+When a subagent tool is called:
+1. Validate the target agent exists and is subagent-capable
+2. Enforce guardrails (depth limit, max turns / timeout)
+3. Spawn a `pi` CLI process with `--mode rpc --system-prompt <agent-file> --no-session`
+4. Send JSON commands over stdin:
+   - `prompt` with the scoped goal
+   - `abort` if timeout or `ctx.signal` fires
+5. Consume JSONL events from stdout, tracking `turn_end` events for max-turns enforcement
+6. On `agent_end`, extract the assistant's response text from `messages`
+7. Kill the RPC process and return the response text as the tool result
+
+### Phase 4: Guardrails & Polish
+- Depth tracking (prevent nested subagent loops)
+- Configurable timeout and max-turns enforcement via CLI flags
+- Self-invocation prevention
+- Clean error handling for missing binary, timeout, or agent-not-found
+
+### Phase 5: Documentation
+- README section on subagent usage
+- Example agent frontmatter with `subagent: true` and `tool_schema`
+- Example: Planner calling Reviewer as subagent
+
+## Requirements
+
+1. Agent frontmatter supports `subagent: true` to mark an agent as callable as a subagent [explicit]
+2. Agent frontmatter supports optional `tool_schema` field declaring tool parameters (e.g., `goal`, `files_to_review`) [explicit]
+3. Subagent-capable agents are auto-registered as Pi tools at extension load and on reload [explicit]
+4. An agent can invoke another agent via the generated tool call [explicit]
+5. Subagent execution is bounded by timeout (enforced via `AbortSignal` + process kill) and max turns (enforced by counting `turn_end` events in the RPC stream) [explicit]
+6. Subagent output is returned to caller as a tool result text block [explicit]
+7. Caller agent identity, history, and context are preserved (process isolation guarantees this) [explicit]
+8. Nested subagent depth is limited to prevent infinite loops [inferred]
+9. Subagent tool registration is refreshed on `/reload` [inferred]
+10. Subagent tool names must not collide with existing tools or the `switch_agent` tool [inferred]
+
+## Task Breakdown
+
+### Task 1: Extend Agent Frontmatter Schema
+- **Goal**: Add `subagent`, `tool_schema`, and `tool_name` fields to agent definitions.
+- **Dependencies**: None.
+- **Files Affected**: `src/agent-discovery.ts`
+- **New Files**: None.
+- **Interfaces**:
+  ```typescript
+  interface AgentDefinition {
+    name: string;
+    path: string;
+    description: string;
+    content: string;
+    subagent?: boolean;
+    toolName?: string;          // override derived tool name
+    toolSchema?: ToolParameter[]; // params beyond the default "goal"
+  }
+
+  interface ToolParameter {
+    name: string;
+    type: "string" | "number" | "boolean";
+    description: string;
+    required?: boolean;
+  }
+  ```
+- **Details**: Update `discoverAgents()` to parse `subagent`, `tool_name`, and `tool_schema` from YAML frontmatter. If `tool_name` is absent, derive it as `invoke_${agentName}` with kebab-case normalization. Store the parsed fields in `AgentDefinition`.
+
+### Task 2: Build TypeBox Schema from Agent Tool Schema
+- **Goal**: Convert `toolSchema` into a `typebox` `Type.Object()` schema for dynamic tool registration.
+- **Dependencies**: Task 1.
+- **Files Affected**: `src/index.ts` (or new `src/subagent-tools.ts`)
+- **New Files**: `src/subagent-tools.ts`
+- **Interfaces**: `function buildSubagentToolSchema(agent: AgentDefinition): TObject`
+- **Details**: Map custom `toolSchema` fields plus a mandatory `goal: Type.String()` into a TypeBox object. Handle `string`, `number`, and `boolean` types. Required fields become `Type.String()` (no `Type.Optional()`).
+
+### Task 3: Register Subagent Tools at Extension Load
+- **Goal**: After agent discovery, auto-register each `subagent: true` agent as a Pi tool.
+- **Dependencies**: Task 1, Task 2.
+- **Files Affected**: `src/index.ts`
+- **New Files**: None.
+- **Interfaces**:
+  ```typescript
+  pi.registerTool({
+    name: derivedToolName,
+    label: `Invoke ${agentName}`,
+    description: agent.description || `Invoke ${agentName} as a subagent`,
+    promptSnippet: `Invoke ${agentName} with a scoped goal`,
+    parameters: builtSchema,
+    execute: subagentExecuteFactory(agent),
+  });
+  ```
+- **Details**: Call registration inside a new helper `registerSubagentTools(pi, agents)` invoked after `discoverAgents()` in the `session_start` handler and also from a `/reload` listener (if available; otherwise rely on `session_shutdown` cache clearing). Ensure no collisions: skip registration if `pi.getAllTools()` already contains the derived name.
+
+### Task 4: Implement Subagent Tool Execution via RPC Mode
+- **Goal**: Spawn a `pi --mode rpc` child process, drive it via JSONL commands, and extract the subagent's final response.
+- **Dependencies**: Task 3.
+- **Files Affected**: `src/subagent-tools.ts` (or `src/index.ts`)
+- **New Files**: `src/subagent-tools.ts`, `src/rpc-client.ts`
+- **Interfaces**:
+  ```typescript
+  // Lightweight JSONL RPC client for subagent invocation
+  class PiRpcClient {
+    constructor(args: string[], options: SpawnOptions);
+    async start(): Promise<void>;
+    async sendPrompt(message: string): Promise<void>;
+    async abort(): Promise<void>;
+    async waitForCompletion(options: { signal?: AbortSignal; timeoutMs: number; maxTurns?: number }): Promise<AgentEndEvent>;
+    kill(): void;
+  }
+
+  async function executeSubagent(
+    agent: AgentDefinition,
+    params: Record<string, unknown>,
+    signal: AbortSignal,
+    timeoutMs: number,
+    maxTurns: number,
+  ): Promise<{ output: string; turnCount: number; timedOut: boolean }>
+  ```
+- **Details**:
+  1. Read the agent's content from `agent.path` (or use `agent.content` if in-memory)
+  2. Compose the prompt: combine `goal` + any additional `toolSchema` parameters into a single prompt string
+  3. Spawn `pi` with `child_process.spawn("pi", ["--mode", "rpc", "--system-prompt", agent.path, "--no-session"], { stdio: ["pipe", "pipe", "pipe"] })`
+  4. Implement `PiRpcClient` in `src/rpc-client.ts`:
+     - **Stdin**: write JSON commands (`prompt`, `abort`) followed by `\n`
+     - **Stdout**: read JSONL lines, parse each as `RpcEvent`
+     - **Event handling**: track `turn_start`/`turn_end` for turn counting; on `agent_end`, capture `messages` array
+     - **Cancellation**: listen to `signal` and send `abort`; also kill the process on timeout
+  5. Extract the assistant's response from the last `assistant` message in `agent_end.messages`
+  6. If `maxTurns` is exceeded, send `abort` and return an error result
+  7. If the process exits without `agent_end`, return an error result
+  8. If `pi` binary is not found, return a graceful error
+  9. Return the extracted text as the subagent response
+
+### Task 5: Add Guardrails (Depth Limit, Timeout, Self-Invocation)
+- **Goal**: Prevent runaway subagent invocations.
+- **Dependencies**: Task 4.
+- **Files Affected**: `src/subagent-tools.ts`, `src/index.ts`
+- **New Files**: None.
+- **Interfaces**:
+  ```typescript
+  const MAX_SUBAGENT_DEPTH = 3;
+  ```
+- **Details**:
+  1. Track subagent depth via an `AsyncLocalStorage` or module-level `subagentDepth` counter incremented/decremented around `executeSubagent`
+  2. If `depth > MAX_SUBAGENT_DEPTH`, return error: "Subagent depth limit exceeded"
+  3. Register a new CLI flag `subagent-timeout` with default `60000` (ms)
+  4. If a subagent tries to invoke itself (name matches active agent and `switch_agent`-style self-check), return error
+  5. On timeout, return error result with `isError: true`
+
+### Task 6: Refresh Subagent Tools on `/reload`
+- **Goal**: Ensure newly added/removed subagent agents are reflected without restarting Pi.
+- **Dependencies**: Task 3.
+- **Files Affected**: `src/index.ts`
+- **New Files**: None.
+- **Details**: In the existing `session_shutdown` handler (which already calls `clearAgentCache()`), also clear any registered subagent tool state. On the next `session_start`, `discoverAgents()` will re-run and `registerSubagentTools()` will re-register. Note: Pi may require re-binding; if `pi.registerTool()` at runtime causes immediate refresh (per docs), this should work.
+
+### Task 7: Update README with Subagent Documentation
+- **Goal**: Document how to declare, invoke, and configure subagents.
+- **Dependencies**: Task 1–Task 5.
+- **Files Affected**: `README.md`
+- **New Files**: None.
+- **Details**: Add a "Subagents" section covering:
+  - Adding `subagent: true` and `tool_schema` to agent frontmatter
+  - Example: Planner invoking Reviewer
+  - Distinction from `switch_agent` (permanent handoff vs. call-and-return)
+  - CLI flags: `--subagent-timeout`, `--agent-switch-confirm`
+  - Guardrails: depth limits, timeout
+
+### Task 8: Update Agent Discovery Unit / Integration Tests
+- **Goal**: Verify subagent frontmatter parsing and tool schema generation.
+- **Dependencies**: Task 1, Task 2.
+- **Files Affected**: `src/agent-discovery.ts`
+- **New Files**: `tests/agent-discovery.test.ts` (if test infrastructure exists; otherwise manual verification)
+- **Details**: If the project has a test runner (jest, vitest), add tests for `discoverAgents()` parsing `subagent`, `tool_name`, and `tool_schema`. Otherwise, verify manually with sample `.pi/agents/reviewer.md`.
+
+## Dependency Graph
+
+- Task 1 → Task 2 (Task 2 parses schema discovered in Task 1)
+- Task 1 → Task 3 (Task 3 registers tools for agents discovered in Task 1)
+- Task 2 → Task 3 (Task 3 uses schemas built in Task 2)
+- Task 3 → Task 4 (Task 4 implements the execute handler for tools registered in Task 3)
+- Task 4 → Task 5 (Task 5 wraps Task 4 with guardrails)
+- Task 3 → Task 6 (Task 6 refreshes what Task 3 registers)
+- Task 5 → Task 7 (Task 7 documents guardrails from Task 5)
+- Task 1 || Task 8 (Task 8 tests Task 1; parallelizable)
+
+## Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---|---|
+| `pi` binary not in PATH during subagent spawn | High | Medium | Check `which pi` or `pi --version` before spawning; return graceful error with install instructions |
+| Token cost double-billing (caller + subagent process) | Medium | High | Document clearly in README; allow `--subagent-dry-run` flag that returns composed prompt instead of spawning |
+| `pi.exec()` timeout or cancellation not propagated cleanly to child process | Medium | Medium | Pass `signal` explicitly; test with long-running subagent and Ctrl+C |
+| Subagent tool name collision with built-in or other extension tools | Medium | Low | Prefix all subagent tools with `invoke_`; check `pi.getAllTools()` before registration; skip on collision |
+| `registerTool()` at runtime does not immediately refresh tool list for current LLM context | High | Low | Test with live Pi session; if needed, call `pi.sendUserMessage("/reload")` after registration (documented workaround) |
+| Nested depth tracking with concurrent parallel tool calls is unreliable | Medium | Medium | Use `AsyncLocalStorage` from `node:async_hooks` for per-execution-context depth rather than global counter |
+| RPC JSONL protocol parsing errors or malformed events | Medium | Low | Validate each line is valid JSON before parsing; catch and return error result on parse failure |
+| RPC subagent hangs waiting for tool call results (e.g., `bash` waiting for input) | High | Low | Use `--no-session` and ensure subagent tools don't require interactive input; enforce strict timeout |
+| Concurrent subagent RPC processes exhaust system resources | Medium | Low | Limit concurrent subagents (1 per caller turn); depth guardrails help; document performance implications |
+
+## Validation Criteria
+
+- [ ] An agent file with `subagent: true` in frontmatter is discovered and appears as a callable tool in Pi's tool list
+- [ ] Calling the subagent tool (e.g., `invoke_reviewer`) spawns a `pi` child process, returns output text, and the caller agent continues unchanged
+- [ ] The caller agent's `activeAgentName` and session history are identical before and after the subagent call
+- [ ] Exceeding `MAX_SUBAGENT_DEPTH` returns an error result instead of spawning another process
+- [ ] Missing `pi` binary produces a clear error result, not a crash
+- [ ] Timeout kills the child process and returns an error result
+- [ ] README contains a working example of a Planner invoking a Reviewer subagent
+- [ ] `/reload` causes newly added `subagent: true` agents to appear as tools without restarting Pi

--- a/README.md
+++ b/README.md
@@ -202,6 +202,77 @@ continues from the full conversation history.
 pattern — the caller resumes after the subagent finishes. `switch_agent` is a
 permanent transfer — the caller agent is replaced and does not resume.
 
+### Subagents
+
+Subagents allow an active agent to **invoke another agent as a tool** for a
+scoped task, receive its output, and **resume its own workflow** — all without
+changing identity or losing context. This is the call-and-return pattern,
+distinct from the permanent handoff of `switch_agent`.
+
+#### Declaring a Subagent
+
+Mark an agent as invocable as a subagent by adding `subagent: true` to its
+YAML frontmatter. You can optionally declare additional tool parameters
+via `tool_schema`:
+
+```markdown
+---
+description: "Reviews code and architecture decisions for risks"
+subagent: true
+tool_schema:
+  - name: files_to_review
+    type: string
+    description: "Comma-separated list of file paths to review"
+    required: false
+---
+
+You are a code reviewer. Your role is to identify risks, suggest improvements,
+and evaluate trade-offs in software architecture and implementation.
+```
+
+When `subagent: true` is present, the extension automatically registers a
+tool named `invoke_{agent-name}` (override with `tool_name`). The tool
+always accepts a `goal` parameter, plus any custom parameters declared in
+`tool_schema`.
+
+#### Invoking a Subagent
+
+The active agent calls the subagent like any other tool:
+
+```tool
+invoke_reviewer(goal="Review this architecture decision. Do you see any risks?")
+```
+
+The subagent spawns in an isolated `pi --mode rpc` process with its own
+system prompt, executes the scoped goal (including any tool calls it needs,
+such as `read` or `bash`), and returns its final response as a tool result.
+The caller agent's identity, session, and history are completely unchanged.
+
+**Example scenario:**
+
+The **Planner** agent is designing a system and wants the **Reviewer** to
+critique a specific decision:
+
+> "Before I commit to this approach, let me get a second opinion."
+> ```tool
+> invoke_reviewer(
+>   goal="Review this architecture: we will use PostgreSQL for the primary store and Redis for caching. What are the operational risks?"
+> )
+> ```
+
+The Reviewer runs in its own process, analyzes the architecture, and
+returns feedback. The Planner receives the result and continues planning.
+
+#### Guardrails
+
+- **Self-invocation prevention**: An agent cannot invoke itself as a subagent.
+- **Depth limit**: Subagent nesting is limited to 3 levels. Deeper nesting
+  returns an error.
+- **Timeout**: Subagent RPC processes are killed after a configurable timeout
+  (default 60 seconds). Pass `--subagent-timeout <ms>` to override.
+- **Max turns**: Subagents are limited to a configurable number of turns
+  (default 5). Pass `--subagent-max-turns <n>` to override.
+
 ### Session Persistence
 
 The active agent is persisted in the session file and restored when you:

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -35,6 +35,18 @@ function getAgentSearchPaths(cwd: string): SearchPath[] {
   ];
 }
 
+/** Parameter declaration for a subagent tool schema. */
+export interface ToolParameter {
+  /** Parameter name */
+  name: string;
+  /** Parameter type */
+  type: "string" | "number" | "boolean";
+  /** Human-readable description for the LLM */
+  description: string;
+  /** Whether the parameter is required */
+  required?: boolean;
+}
+
 /** Represents a discovered agent definition from an agent file. */
 export interface AgentDefinition {
   /** Agent name (e.g., "planner") */
@@ -45,6 +57,12 @@ export interface AgentDefinition {
   description: string;
   /** Markdown body (frontmatter stripped) capturing the agent's role */
   content: string;
+  /** Whether this agent can be invoked as a subagent tool */
+  subagent?: boolean;
+  /** Override for the generated tool name (default: invoke_{kebab-case name}) */
+  toolName?: string;
+  /** Additional tool parameters beyond the default `goal` */
+  toolSchema?: ToolParameter[];
 }
 
 /** Module-level cache for discovered agents within a session. */
@@ -123,11 +141,49 @@ export async function discoverAgents(
             ? frontmatter.description
             : "";
 
+        const subagent =
+          frontmatter.subagent === true || frontmatter.subagent === "true";
+
+        const toolName =
+          typeof frontmatter.tool_name === "string" && frontmatter.tool_name
+            ? frontmatter.tool_name
+            : `invoke_${agentName.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+
+        let toolSchema: ToolParameter[] | undefined;
+        if (
+          Array.isArray(frontmatter.tool_schema) &&
+          frontmatter.tool_schema.every(
+            (p: unknown) =>
+              typeof p === "object" &&
+              p !== null &&
+              "name" in p &&
+              typeof (p as Record<string, unknown>).name === "string" &&
+              "type" in p &&
+              typeof (p as Record<string, unknown>).type === "string" &&
+              "description" in p &&
+              typeof (p as Record<string, unknown>).description === "string",
+          )
+        ) {
+          toolSchema = (frontmatter.tool_schema as ToolParameter[]).map(
+            (p) => ({
+              name: p.name,
+              type: ["string", "number", "boolean"].includes(p.type)
+                ? p.type
+                : "string",
+              description: p.description,
+              required: p.required === true,
+            }),
+          );
+        }
+
         agentsByName.set(agentName, {
           name: agentName,
           path: filePath,
           description,
           content: body,
+          subagent,
+          toolName,
+          toolSchema,
         });
       } catch (err) {
         console.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,24 @@ import type { AgentDefinition } from "./agent-discovery.js";
 import { discoverAgents, clearAgentCache } from "./agent-discovery.js";
 import { Type } from "typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
+import { buildSubagentToolSchema, executeSubagent } from "./subagent-tools.js";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 export default function (pi: ExtensionAPI) {
   let activeAgentName: string | undefined;
+  const registeredSubagentTools = new Set<string>();
+  const MAX_SUBAGENT_DEPTH = 3;
+  const subagentStorage = new AsyncLocalStorage<{ depth: number }>();
+
+  function getSubagentDepth(): number {
+    const store = subagentStorage.getStore();
+    return store?.depth ?? 0;
+  }
+
+  function withSubagentDepth<T>(fn: () => Promise<T>): Promise<T> {
+    const currentDepth = getSubagentDepth();
+    return subagentStorage.run({ depth: currentDepth + 1 }, fn);
+  }
 
   function updateAgentStatus(ctx: ExtensionContext, name: string | undefined) {
     if (ctx.hasUI) {
@@ -28,11 +43,114 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  function registerSubagentTools(agents: AgentDefinition[]) {
+    for (const agent of agents) {
+      if (!agent.subagent || !agent.toolName) continue;
+
+      if (registeredSubagentTools.has(agent.toolName)) continue;
+
+      if (agent.toolName === "switch_agent") {
+        console.warn(
+          `[pi-agents] Subagent tool name "${agent.toolName}" collides with switch_agent, skipping`,
+        );
+        continue;
+      }
+
+      registeredSubagentTools.add(agent.toolName);
+
+      const schema = buildSubagentToolSchema(agent);
+
+      pi.registerTool({
+        name: agent.toolName,
+        label: `Invoke ${agent.name}`,
+        description:
+          agent.description || `Invoke ${agent.name} as a subagent`,
+        promptSnippet: `Invoke the ${agent.name} subagent with a scoped goal`,
+        promptGuidelines: [
+          `Use ${agent.toolName} when you need the ${agent.name} agent to perform a specific, scoped task and return its output. The caller agent will resume after the subagent completes.`,
+        ],
+        parameters: schema,
+        async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
+          // Self-invocation guardrail
+          if (activeAgentName === agent.name) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Cannot invoke subagent ${agent.name} because it is the currently active agent.`,
+                },
+              ],
+              details: {},
+              isError: true,
+            };
+          }
+
+          // Depth limit guardrail
+          const depth = getSubagentDepth();
+          if (depth >= MAX_SUBAGENT_DEPTH) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Subagent depth limit (${MAX_SUBAGENT_DEPTH}) exceeded. Cannot nest deeper than ${MAX_SUBAGENT_DEPTH} levels.`,
+                },
+              ],
+              details: { currentDepth: depth },
+              isError: true,
+            };
+          }
+
+          const timeoutMs =
+            parseInt(
+              (pi.getFlag("subagent-timeout") as string | undefined) ??
+                "60000",
+              10,
+            ) || 60000;
+          const maxTurns =
+            parseInt(
+              (pi.getFlag("subagent-max-turns") as string | undefined) ?? "5",
+              10,
+            ) || 5;
+
+          const result = await withSubagentDepth(() =>
+            executeSubagent(agent, params, signal, timeoutMs, maxTurns),
+          );
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: result.output,
+              },
+            ],
+            details: {
+              turnCount: result.turnCount,
+              timedOut: result.timedOut,
+              subagentDepth: depth + 1,
+            },
+          };
+        },
+      });
+    }
+  }
+
   // --- Task 3: Register CLI flag for agent switch confirmation ---
   pi.registerFlag("agent-switch-confirm", {
     description: "Confirm before agent-initiated agent switches",
     type: "boolean",
     default: true,
+  });
+
+  pi.registerFlag("subagent-timeout", {
+    description: "Default timeout in milliseconds for subagent RPC execution",
+    type: "string",
+    default: "60000",
+  });
+
+  pi.registerFlag("subagent-max-turns", {
+    description: "Maximum turns a subagent can execute before being forcibly stopped",
+    type: "string",
+    default: "5",
   });
 
   // --- Task 3: Active Agent State Persistence ---
@@ -59,6 +177,9 @@ export default function (pi: ExtensionAPI) {
       activeAgentName = undefined;
       updateAgentStatus(ctx, undefined);
     }
+
+    const agents = await discoverAgents(pi, ctx.cwd);
+    registerSubagentTools(agents);
   });
 
   // --- Task 6: Inject Active Agent System Instructions ---
@@ -76,6 +197,7 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_shutdown", async () => {
     clearAgentCache();
+    registeredSubagentTools.clear();
   });
 
   // --- Task 4: /agent Command and Visual Mode Switching ---

--- a/src/rpc-client.ts
+++ b/src/rpc-client.ts
@@ -1,0 +1,193 @@
+import { spawn, type ChildProcess } from "node:child_process";
+
+export interface AgentMessage {
+  role: string;
+  content:
+    | string
+    | Array<{ type: string; text?: string; thinking?: string }>;
+}
+
+export interface AgentEndEvent {
+  type: "agent_end";
+  messages: AgentMessage[];
+}
+
+export interface PiRpcClientOptions {
+  timeoutMs: number;
+  maxTurns?: number;
+  signal?: AbortSignal;
+}
+
+export class PiRpcClient {
+  private proc: ChildProcess;
+  private buffer = "";
+  private decoder = new TextDecoder();
+  private resolveCompletion: ((value: AgentEndEvent) => void) | null = null;
+  private rejectCompletion: ((reason: Error) => void) | null = null;
+  private turnCount = 0;
+  private maxTurns: number | undefined;
+  private timeoutId: NodeJS.Timeout | null = null;
+  private killed = false;
+
+  constructor(args: string[]) {
+    this.proc = spawn("pi", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this.proc.stdout?.on("data", (chunk: Buffer) => {
+      this.onStdoutData(chunk);
+    });
+
+    this.proc.stderr?.on("data", (chunk: Buffer) => {
+      console.error("[pi-agents subagent stderr]", chunk.toString());
+    });
+
+    this.proc.on("error", (err) => {
+      if (this.rejectCompletion) {
+        this.rejectCompletion(
+          new Error(`Subagent process error: ${err.message}`),
+        );
+        this.rejectCompletion = null;
+        this.resolveCompletion = null;
+      }
+    });
+
+    this.proc.on("exit", (code, signal) => {
+      if (!this.resolveCompletion && !this.rejectCompletion) return;
+
+      const reason = signal
+        ? `Subagent process killed by signal ${signal}`
+        : `Subagent process exited with code ${code}`;
+
+      if (this.rejectCompletion) {
+        this.rejectCompletion(new Error(reason));
+        this.rejectCompletion = null;
+        this.resolveCompletion = null;
+      }
+    });
+  }
+
+  private onStdoutData(chunk: Buffer) {
+    this.buffer += this.decoder.decode(chunk, { stream: true });
+
+    while (true) {
+      const nlIndex = this.buffer.indexOf("\n");
+      if (nlIndex === -1) break;
+
+      let line = this.buffer.slice(0, nlIndex);
+      this.buffer = this.buffer.slice(nlIndex + 1);
+
+      if (line.endsWith("\r")) {
+        line = line.slice(0, -1);
+      }
+
+      if (!line.trim()) continue;
+
+      try {
+        const event = JSON.parse(line);
+        this.handleEvent(event);
+      } catch {
+        console.error("[pi-agents] Failed to parse RPC event:", line);
+      }
+    }
+  }
+
+  private handleEvent(event: Record<string, unknown>) {
+    if (event.type === "turn_end") {
+      this.turnCount++;
+      if (this.maxTurns && this.turnCount > this.maxTurns) {
+        this.sendCommand({ type: "abort" });
+        this.kill();
+        if (this.rejectCompletion) {
+          this.rejectCompletion(
+            new Error(`Subagent exceeded maximum ${this.maxTurns} turns`),
+          );
+          this.rejectCompletion = null;
+          this.resolveCompletion = null;
+        }
+      }
+    } else if (event.type === "agent_end") {
+      if (this.timeoutId) {
+        clearTimeout(this.timeoutId);
+        this.timeoutId = null;
+      }
+      if (this.resolveCompletion) {
+        this.resolveCompletion(event as AgentEndEvent);
+        this.resolveCompletion = null;
+        this.rejectCompletion = null;
+      }
+    }
+  }
+
+  private sendCommand(cmd: Record<string, unknown>): void {
+    if (!this.proc.stdin || this.killed) return;
+    this.proc.stdin.write(JSON.stringify(cmd) + "\n");
+  }
+
+  async start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const onError = (err: Error) => {
+        reject(
+          new Error(`Failed to start subagent process: ${err.message}`),
+        );
+      };
+      this.proc.once("error", onError);
+
+      setTimeout(() => {
+        this.proc.off("error", onError);
+        resolve();
+      }, 500);
+    });
+  }
+
+  async sendPrompt(message: string): Promise<void> {
+    this.sendCommand({ type: "prompt", message });
+  }
+
+  async abort(): Promise<void> {
+    this.sendCommand({ type: "abort" });
+  }
+
+  async waitForCompletion(options: PiRpcClientOptions): Promise<AgentEndEvent> {
+    this.maxTurns = options.maxTurns;
+
+    return new Promise((resolve, reject) => {
+      this.resolveCompletion = resolve;
+      this.rejectCompletion = reject;
+
+      this.timeoutId = setTimeout(() => {
+        this.kill();
+        reject(new Error("Subagent execution timed out"));
+      }, options.timeoutMs);
+
+      if (options.signal) {
+        options.signal.addEventListener("abort", () => {
+          this.kill();
+          reject(new Error("Subagent execution cancelled"));
+        });
+      }
+    });
+  }
+
+  getTurnCount(): number {
+    return this.turnCount;
+  }
+
+  kill(): void {
+    if (this.killed) return;
+    this.killed = true;
+
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+
+    this.proc.stdin?.end();
+
+    setTimeout(() => {
+      if (!this.proc.killed) {
+        this.proc.kill();
+      }
+    }, 100);
+  }
+}

--- a/src/subagent-tools.ts
+++ b/src/subagent-tools.ts
@@ -1,0 +1,151 @@
+import { Type, type TSchema } from "typebox";
+import { writeFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentDefinition, ToolParameter } from "./agent-discovery.js";
+import { PiRpcClient } from "./rpc-client.js";
+
+/**
+ * Builds a TypeBox schema for a subagent tool from an AgentDefinition.
+ *
+ * Every subagent tool receives a mandatory `goal` parameter. Additional
+ * parameters declared in the agent's `toolSchema` frontmatter are merged in.
+ */
+export function buildSubagentToolSchema(
+  agent: AgentDefinition,
+): TSchema {
+  const properties: Record<string, TSchema> = {
+    goal: Type.String({
+      description: `The scoped goal or task for the ${agent.name} subagent`,
+    }),
+  };
+
+  if (agent.toolSchema) {
+    for (const param of agent.toolSchema) {
+      let schema: TSchema;
+      switch (param.type) {
+        case "number":
+          schema = Type.Number({ description: param.description });
+          break;
+        case "boolean":
+          schema = Type.Boolean({ description: param.description });
+          break;
+        case "string":
+        default:
+          schema = Type.String({ description: param.description });
+          break;
+      }
+
+      if (!param.required) {
+        schema = Type.Optional(schema);
+      }
+
+      properties[param.name] = schema;
+    }
+  }
+
+  return Type.Object(properties);
+}
+
+/**
+ * Execute a subagent via a separate Pi RPC process.
+ *
+ * Spawns `pi --mode rpc` with the agent's content as system prompt,
+ * sends the composed goal, and extracts the final assistant response
+ * from the `agent_end` event.
+ */
+export async function executeSubagent(
+  agent: AgentDefinition,
+  params: Record<string, unknown>,
+  signal: AbortSignal,
+  timeoutMs: number,
+  maxTurns: number,
+): Promise<{ output: string; turnCount: number; timedOut: boolean }> {
+  // Compose the prompt from goal + toolSchema params
+  const goal = String(params.goal ?? "");
+  let prompt = goal;
+
+  if (agent.toolSchema) {
+    for (const param of agent.toolSchema) {
+      if (param.name !== "goal" && params[param.name] !== undefined) {
+        prompt += `\n\n${param.name}: ${String(params[param.name])}`;
+      }
+    }
+  }
+
+  // Write agent content (frontmatter stripped) to a temp file for --system-prompt
+  const tempPath = join(
+    tmpdir(),
+    `pi-subagent-${Date.now()}-${agent.name.replace(/[^a-zA-Z0-9_-]/g, "-")}.md`,
+  );
+  await writeFile(tempPath, agent.content, "utf-8");
+
+  const client = new PiRpcClient([
+    "--mode",
+    "rpc",
+    "--system-prompt",
+    tempPath,
+    "--no-session",
+  ]);
+
+  let timedOut = false;
+  let output = "";
+  let turnCount = 0;
+
+  try {
+    await client.start();
+    await client.sendPrompt(prompt);
+
+    const result = await client.waitForCompletion({
+      signal,
+      timeoutMs,
+      maxTurns,
+    });
+
+    turnCount = client.getTurnCount();
+
+    // Extract the last assistant message's text content
+    const assistantMessages = result.messages.filter(
+      (m) => m.role === "assistant",
+    );
+    const lastAssistant = assistantMessages[assistantMessages.length - 1];
+
+    if (lastAssistant) {
+      if (typeof lastAssistant.content === "string") {
+        output = lastAssistant.content;
+      } else if (Array.isArray(lastAssistant.content)) {
+        output = lastAssistant.content
+          .filter((c) => c.type === "text")
+          .map((c) => c.text ?? "")
+          .join("");
+      }
+    } else {
+      output = "[Subagent completed with no assistant response]";
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.includes("timed out")) {
+        timedOut = true;
+        output = `Subagent ${agent.name} timed out after ${timeoutMs}ms.`;
+      } else if (err.message.includes("cancelled")) {
+        output = `Subagent ${agent.name} was cancelled.`;
+      } else if (err.message.includes("exceeded maximum")) {
+        output = err.message;
+      } else if (
+        err.message.includes("exited with code") ||
+        err.message.includes("killed by signal")
+      ) {
+        output = `Subagent ${agent.name} process ended unexpectedly: ${err.message}`;
+      } else {
+        output = `Subagent ${agent.name} failed: ${err.message}`;
+      }
+    } else {
+      output = `Subagent ${agent.name} failed: ${String(err)}`;
+    }
+  } finally {
+    client.kill();
+    await unlink(tempPath).catch(() => {});
+  }
+
+  return { output, turnCount, timedOut };
+}


### PR DESCRIPTION
Design:
  Agents with `subagent: true` are auto-registered as Pi tools
  (e.g. `invoke_reviewer`). Each subagent spawns a `pi --mode rpc`
  subprocess with its own system prompt, executes the goal, and
  returns the final assistant response. The caller's context is
  fully preserved.

  Agent frontmatter gains `subagent`, `tool_name`, and
  `tool_schema` fields. Tool schemas use TypeBox with a
  mandatory `goal` parameter.

  Guardrails: self-invocation prevention, depth limit (max 3)
  via AsyncLocalStorage, and bounded execution via RPC turn
  counting and timeout.

Tradeoffs:
  - RPC subprocess is heavyweight but gives true isolation, correct system prompts, and subagent tool access.
  - Separate token billing for caller and subagent.
  - `pi` binary must be in PATH.
  - Subagent processes lack this extension, preventing uncontrolled nesting.

Justification:
  Issue #3 needs call-and-return subagents distinct from the
  permanent `switch_agent` handoff. The Pi extension API has
  no native nested agent execution; RPC subprocess is the most
  capable approach available.

Rel: https://github.com/andrewhowdencom/pi.agents/issues/3