### PR TITLE
Prevent subagent hang when RPC process exits early

### DIFF
--- a/src/rpc-client.ts
+++ b/src/rpc-client.ts
@@ -48,6 +48,7 @@ export class PiRpcClient {
   private killed = false;
   private eventListeners: RpcEventListener[] = [];
   private accumulatedUsage: AccumulatedUsage | undefined;
+  private exitInfo: { code: number | null; signal: string | null } | null = null;
 
   constructor(args: string[]) {
     this.proc = spawn("pi", args, {
@@ -73,7 +74,7 @@ export class PiRpcClient {
     });
 
     this.proc.on("exit", (code, signal) => {
-      if (!this.resolveCompletion && !this.rejectCompletion) return;
+      this.exitInfo = { code, signal };
 
       const reason = signal
         ? `Subagent process killed by signal ${signal}`
@@ -245,6 +246,16 @@ export class PiRpcClient {
     return new Promise((resolve, reject) => {
       this.resolveCompletion = resolve;
       this.rejectCompletion = reject;
+
+      if (this.exitInfo) {
+        const reason = this.exitInfo.signal
+          ? `Subagent process killed by signal ${this.exitInfo.signal}`
+          : `Subagent process exited with code ${this.exitInfo.code}`;
+        reject(new Error(reason));
+        this.rejectCompletion = null;
+        this.resolveCompletion = null;
+        return;
+      }
 
       if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
         this.timeoutId = setTimeout(() => {


### PR DESCRIPTION
When a subagent is invoked with an invalid model (or any other early initialization failure), the spawned pi --mode rpc process may crash after start() resolves but before waitForCompletion() sets up its promise handlers. In this case, the exit event was silently swallowed because the exit handler bailed early when resolveCompletion and rejectCompletion were still null.

Store exit information on the PiRpcClient instance and check it inside waitForCompletion() after setting up the promise handlers. This ensures the subagent fails immediately with a clear error instead of hanging forever.

Fixes #20