### PR TITLE
Implement idle-timeout default for subagent execution

### DIFF
--- a/docs/reference/subagent-frontmatter.md
+++ b/docs/reference/subagent-frontmatter.md
@@ -42,7 +42,7 @@ compatibility.
 |---|---|---|---|
 | `role` | string array | `["leader"]` | Capabilities of this agent: `"leader"` and/or `"delegate"` |
 | `model` | string | *(Pi default)* | LLM model for this delegate (e.g., `anthropic/claude-sonnet-4`, `openai/gpt-4.1`). Passed as `--model` to the delegate's RPC process. |
-| `timeout` | number | `60000` | RPC timeout in milliseconds. The delegate process is killed if it exceeds this. |
+| `timeout` | number | `60000` | RPC idle-timeout in milliseconds. The timer resets on each stdout event from the delegate. The delegate is killed only if it goes silent for longer than this duration. |
 | `max_turns` | number | `30` | Maximum turns before the delegate is forcibly stopped. |
 | `tool_name` | string | `invoke_{name}` | **Deprecated.** Unused with unified `delegate_agent` tool. |
 | `tool_schema` | array | — | **Deprecated.** Custom parameters are no longer supported; embed structured data in the `goal` string instead. |

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -65,7 +65,7 @@ export interface AgentDefinition {
   toolSchema?: ToolParameter[];
   /** LLM model for this delegate (e.g. "anthropic/claude-sonnet-4") */
   model?: string;
-  /** RPC timeout in milliseconds. When not specified, the delegate runs until completion (no timeout). */
+  /** RPC idle-timeout in milliseconds. When not specified, defaults to 60000ms (60 seconds). The timer resets on every stdout event; only subagents that go silent for this duration are killed. */
   timeout?: number;
   /** Maximum turns before forcible stop. When not specified, the delegate runs until completion (no limit). */
   maxTurns?: number;

--- a/src/rpc-client.ts
+++ b/src/rpc-client.ts
@@ -44,7 +44,8 @@ export class PiRpcClient {
   private rejectCompletion: ((reason: Error) => void) | null = null;
   private turnCount = 0;
   private maxTurns: number | undefined;
-  private timeoutId: NodeJS.Timeout | null = null;
+  private idleTimeoutId: NodeJS.Timeout | null = null;
+  private idleTimeoutMs: number | undefined = undefined;
   private killed = false;
   private eventListeners: RpcEventListener[] = [];
   private accumulatedUsage: AccumulatedUsage | undefined;
@@ -76,6 +77,11 @@ export class PiRpcClient {
     this.proc.on("exit", (code, signal) => {
       this.exitInfo = { code, signal };
 
+      if (this.idleTimeoutId) {
+        clearTimeout(this.idleTimeoutId);
+        this.idleTimeoutId = null;
+      }
+
       const reason = signal
         ? `Subagent process killed by signal ${signal}`
         : `Subagent process exited with code ${code}`;
@@ -89,6 +95,9 @@ export class PiRpcClient {
   }
 
   private onStdoutData(chunk: Buffer) {
+    if (this.rejectCompletion && this.idleTimeoutMs) {
+      this.setIdleTimeout(this.rejectCompletion);
+    }
     this.buffer += this.decoder.decode(chunk, { stream: true });
 
     while (true) {
@@ -199,15 +208,29 @@ export class PiRpcClient {
         }
       }
     } else if (event.type === "agent_end") {
-      if (this.timeoutId) {
-        clearTimeout(this.timeoutId);
-        this.timeoutId = null;
+      if (this.idleTimeoutId) {
+        clearTimeout(this.idleTimeoutId);
+        this.idleTimeoutId = null;
       }
+      this.idleTimeoutMs = undefined;
       if (this.resolveCompletion) {
         this.resolveCompletion(event as AgentEndEvent);
         this.resolveCompletion = null;
         this.rejectCompletion = null;
       }
+    }
+  }
+
+  private setIdleTimeout(reject: (reason: Error) => void): void {
+    if (this.idleTimeoutId) {
+      clearTimeout(this.idleTimeoutId);
+      this.idleTimeoutId = null;
+    }
+    if (this.idleTimeoutMs !== undefined && this.idleTimeoutMs > 0) {
+      this.idleTimeoutId = setTimeout(() => {
+        this.kill();
+        reject(new Error("Subagent execution timed out after inactivity"));
+      }, this.idleTimeoutMs);
     }
   }
 
@@ -258,10 +281,8 @@ export class PiRpcClient {
       }
 
       if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
-        this.timeoutId = setTimeout(() => {
-          this.kill();
-          reject(new Error("Subagent execution timed out"));
-        }, options.timeoutMs);
+        this.idleTimeoutMs = options.timeoutMs;
+        this.setIdleTimeout(reject);
       }
 
       if (options.signal) {
@@ -297,10 +318,11 @@ export class PiRpcClient {
     this.eventListeners = [];
     this.accumulatedUsage = undefined;
 
-    if (this.timeoutId) {
-      clearTimeout(this.timeoutId);
-      this.timeoutId = null;
+    if (this.idleTimeoutId) {
+      clearTimeout(this.idleTimeoutId);
+      this.idleTimeoutId = null;
     }
+    this.idleTimeoutMs = undefined;
 
     this.proc.stdin?.end();
 

--- a/src/subagent-tools.ts
+++ b/src/subagent-tools.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import type { AgentDefinition, ToolParameter } from "./agent-discovery.js";
 import { PiRpcClient, type AccumulatedUsage } from "./rpc-client.js";
 
+const DEFAULT_SUBAGENT_TIMEOUT = 60000;
+
 /**
  * Builds a TypeBox schema for a subagent tool from an AgentDefinition.
  *
@@ -66,7 +68,7 @@ export async function executeSubagent(
   signal: AbortSignal,
   onUpdate?: SubagentUpdateCallback,
 ): Promise<{ output: string; turnCount: number; timedOut: boolean; usage?: AccumulatedUsage }> {
-  const timeoutMs = agent.timeout;
+  const effectiveTimeout = agent.timeout ?? DEFAULT_SUBAGENT_TIMEOUT;
   const maxTurns = agent.maxTurns;
   // Compose the prompt from goal + toolSchema params
   const goal = String(params.goal ?? "");
@@ -163,7 +165,7 @@ export async function executeSubagent(
 
     const result = await client.waitForCompletion({
       signal,
-      timeoutMs,
+      timeoutMs: effectiveTimeout,
       maxTurns,
     });
 
@@ -191,7 +193,7 @@ export async function executeSubagent(
     if (err instanceof Error) {
       if (err.message.includes("timed out")) {
         timedOut = true;
-        output = `Subagent ${agent.name} timed out after ${timeoutMs}ms.`;
+        output = `Subagent ${agent.name} timed out after ${effectiveTimeout}ms of inactivity.`;
       } else if (err.message.includes("cancelled")) {
         output = `Subagent ${agent.name} was cancelled.`;
       } else if (err.message.includes("exceeded maximum")) {


### PR DESCRIPTION
Design:
  Replace the one-shot total-execution timeout in PiRpcClient with an
  idle-timeout that resets on every stdout chunk from the subagent
  process. A 60-second default is applied when agent.timeout is omitted
  in frontmatter. Active subagents can run indefinitely; only those that
  go completely silent are killed.

Tradeoffs:
  - Idle timeout is more forgiving than total timeout for slow but active subagents, but requires trusting stdout as an activity signal.
  - Explicit timeout:0 still disables the timer (preserved via ?? operator semantics, where 0 is not null/undefined).

Justification:
  GitHub issue #22 reported indefinite hangs when agent.timeout was
  omitted. The root cause was waitForCompletion() only installing a
  timeout when options.timeoutMs was explicitly set and positive. When
  frontmatter omitted timeout, the value was undefined, and subagents
  that hung (e.g., waiting on an unresponsive LLM provider) blocked the
  parent agent forever. The fix ensures every subagent invocation has a
  bounded recovery path.

Fixes #22