### PR TITLE
Auto-cancel subagent extension UI requests to prevent deadlocks

### DIFF
--- a/src/rpc-client.ts
+++ b/src/rpc-client.ts
@@ -218,6 +218,28 @@ export class PiRpcClient {
         this.resolveCompletion = null;
         this.rejectCompletion = null;
       }
+    } else if (event.type === "extension_ui_request") {
+      const method = event.method as string | undefined;
+      const id = event.id as string | undefined;
+
+      // Dialog methods block until a response is sent. Auto-cancel them
+      // so the subagent does not hang forever.
+      if (
+        id &&
+        (method === "select" ||
+          method === "confirm" ||
+          method === "input" ||
+          method === "editor")
+      ) {
+        console.error(
+          `[pi-agents] Auto-cancelling extension UI request "${method}" (subagent UI is not supported)`,
+        );
+        this.sendCommand({
+          type: "extension_ui_response",
+          id,
+          cancelled: true,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Subagents running in RPC mode can trigger extension UI requests (select, confirm, input, editor) that block forever waiting for a response. The PiRpcClient never handled these, causing both the subagent and parent to deadlock.

Auto-cancel dialog UI requests with cancelled: true so subagents proceed gracefully instead of hanging. Fire-and-forget methods (notify, setStatus, etc.) are left alone as they do not block.